### PR TITLE
Add parentheses in selector

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn mine_function_selector(
 ) -> Option<(u32, String, String)> {
     let mut nonce = nonce_start;
     while nonce < MAX_NONCE && !found.load(Ordering::Relaxed) {
-        let input = format!("{}{}{}", name, nonce, params);
+        let input = format!("{}{}{}{}{}", name, nonce, '(', params, ')');
         let hash = keccak256(input.as_bytes());
         let selector = &hash[..4];
 


### PR DESCRIPTION
在计算函数选择器时没有考虑括号，已添加。